### PR TITLE
Jpa관계 수정(양방향->단방향)

### DIFF
--- a/backend/src/main/java/core/backend/domain/Food.java
+++ b/backend/src/main/java/core/backend/domain/Food.java
@@ -3,11 +3,14 @@ package core.backend.domain;
 import java.util.*;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
-@Getter @Setter
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Food {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -16,7 +19,8 @@ public class Food {
 
     private String name;
 
-    //    @Column(columnDefinition = "TEXT") // TODO(민우) : 뭔지 찾아보기
+    @Lob // 필드 타입 String일 시 CLOB으로 매핑
+    @Column(columnDefinition = "LONGTEXT")
     private String description;
 
     private Integer scoville;
@@ -24,11 +28,12 @@ public class Food {
     private String sort;
 
     private String imgUrl;
-
-    @OneToMany(mappedBy = "food")
-    private List<Review> reviews = new ArrayList<>();;
+/*
+//    @OneToMany(mappedBy ="food", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Review> reviews = new ArrayList<>();;
     // Null Pointer Exception 방지를 위해 초기화
-    @OneToMany(mappedBy = "food") // cascade = CascadeType.REMOVE
-    private List<Heart> hearts = new ArrayList<>();;
-
+//    @OneToMany(mappedBy = "food") // cascade = CascadeType.REMOVE
+//    @OneToMany(mappedBy ="food", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Heart> hearts = new ArrayList<>();;
+*/
 }

--- a/backend/src/main/java/core/backend/domain/Heart.java
+++ b/backend/src/main/java/core/backend/domain/Heart.java
@@ -1,21 +1,24 @@
 package core.backend.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
-@Getter @Setter
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Heart {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="heart_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="food_id")
+    @JoinColumn(name="food_id", nullable = false)
     private Food food;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="member_id")
+    @JoinColumn(name="member_id", nullable = false)
     private Member member;
 }

--- a/backend/src/main/java/core/backend/domain/Member.java
+++ b/backend/src/main/java/core/backend/domain/Member.java
@@ -1,11 +1,14 @@
 package core.backend.domain;
 
+import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Getter
@@ -38,20 +41,17 @@ public class Member {
     private String nationality;
 
     @Column(updatable = false) // 회원가입 시 자동 생성(수정 불가)
+    @CreationTimestamp // 쿼리 Insert 시 현재시간 저장
     private LocalDateTime createDate;
 
     private String badge;
     private String photoUrl;
 
-    //cascade = CascadeType.ALL, orphanRemoval = true -> 회원 삭제 시 리뷰와 좋아요 함께 삭제되는 코드
-    @OneToMany(mappedBy ="member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Review> reviews = new ArrayList<>();
+/*    //cascade = CascadeType.ALL, orphanRemoval = true -> 회원 삭제 시 리뷰와 좋아요 함께 삭제되는 코드
+//    @OneToMany(mappedBy ="member", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Review> reviews = new ArrayList<>();
     // Null Pointer Exception 방지를 위해 초기화
-    @OneToMany(mappedBy ="member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Heart> hearts = new ArrayList<>();
-
-    @PrePersist
-    protected void onCreate(){
-        this.createDate = LocalDateTime.now();
-    }
+//    @OneToMany(mappedBy ="member", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Heart> hearts = new ArrayList<>();
+*/
 }

--- a/backend/src/main/java/core/backend/domain/Review.java
+++ b/backend/src/main/java/core/backend/domain/Review.java
@@ -2,23 +2,28 @@ package core.backend.domain;
 
 import java.time.LocalDateTime;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 
 @Entity
-@Getter @Setter
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Review {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="review_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    //    @JoinColumn(name="food_id")
-
+    @JoinColumn(name="food_id")
+    @NonNull
     private Food food;
 
     @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="member_id")
+    @JoinColumn(name="member_id")
+    @NotNull
     private Member member;
 
     private String content;

--- a/backend/src/main/java/core/backend/domain/SpicyScale.java
+++ b/backend/src/main/java/core/backend/domain/SpicyScale.java
@@ -1,8 +1,11 @@
 package core.backend.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
+@Getter @Setter
+@NoArgsConstructor
 public class SpicyScale {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="spicyscale_id")

--- a/backend/src/main/java/core/backend/repository/HeartRepository.java
+++ b/backend/src/main/java/core/backend/repository/HeartRepository.java
@@ -1,9 +1,12 @@
 package core.backend.repository;
 
+import core.backend.domain.Food;
 import core.backend.domain.Heart;
+import core.backend.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HeartRepository extends JpaRepository<Heart, Long> {
+    boolean existsByFoodAndMember(Food food, Member member);
 }

--- a/backend/src/main/java/core/backend/service/MemberService.java
+++ b/backend/src/main/java/core/backend/service/MemberService.java
@@ -1,0 +1,25 @@
+package core.backend.service;
+
+import java.util.Optional;
+import core.backend.domain.Member;
+import core.backend.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+//    userId, name, nationality, profile_photo
+//    public
+
+    public Member getMember(Long id){
+        Optional<Member> member = memberRepository.findById(id);
+        if (member.isPresent()) {
+            return member.get();
+        } else {
+            throw new IllegalArgumentException("Member not found by id: " + id);
+        }
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=backend
 spring.profiles.include=db
 
-spring.jpa.hibernate.ddl-auto=update
-#spring.jpa.hibernate.ddl-auto=create
+#spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect
 spring.jpa.properties.hibernate.format_sql = true

--- a/backend/src/test/java/core/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/core/backend/controller/AuthControllerTest.java
@@ -1,0 +1,20 @@
+package core.backend.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class AuthControllerTest {
+    @Test
+    @DisplayName("로그인")
+    void login() throws Exception {
+        //given
+
+        //when
+
+        //then
+
+    }
+}

--- a/backend/src/test/java/core/backend/domain/FoodTest.java
+++ b/backend/src/test/java/core/backend/domain/FoodTest.java
@@ -1,0 +1,60 @@
+package core.backend.domain;
+
+import java.util.List;
+import core.backend.repository.FoodRepository;
+import core.backend.repository.HeartRepository;
+import core.backend.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+@Transactional
+class FoodTest {
+    @Autowired
+    FoodRepository foodRepository;
+    @Autowired
+    HeartRepository heartRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Test
+    @DisplayName("Food-Heart")
+    void teset() throws Exception {
+        //given
+        Member member = new Member().builder()
+                .name("test_member")
+                .email("test@test.com")
+                .password("test")
+                .role(RoleType.USER)
+                .nationality("Test Nationality")
+                .build();
+        memberRepository.saveAndFlush(member);
+        Food food1 = new Food().builder()
+                .name("TestFood1")
+                .build();
+        Food food2 = new Food().builder()
+                .name("TestFood2")
+                .build();
+        foodRepository.saveAllAndFlush(List.of(food1, food2));
+
+        Heart heart1 = new Heart().builder()
+                .food(food1)
+                .member(member)
+                .build();
+        Heart heart2 = new Heart().builder()
+            .food(food2)
+            .member(member)
+            .build();
+        heartRepository.saveAllAndFlush(List.of(heart1, heart2));
+
+        //when
+        List<Heart> all = heartRepository.findAll();
+        //then
+        for (Heart heart : all) {
+            System.out.println("heart.getFood(), heart.getMember()\n" + heart.getFood().getName() + " " + heart.getMember().getName());
+        }
+
+    }
+}

--- a/backend/src/test/java/core/backend/jpamapping/JpaMappingTest.java
+++ b/backend/src/test/java/core/backend/jpamapping/JpaMappingTest.java
@@ -1,54 +1,65 @@
-package core.backend.jpamapping;
-
-import core.backend.domain.Food;
-import core.backend.domain.Heart;
-import core.backend.domain.Member;
-import core.backend.repository.FoodRepository;
-import core.backend.repository.HeartRepository;
-import core.backend.repository.MemberRepository;
-import jakarta.transaction.Transactional;
-import org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForCalendar;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.stereotype.Component;
-import java.util.ArrayList;
-import java.util.List;
-import static org.junit.jupiter.api.Assertions.*;
-
-@SpringBootTest
-@Transactional
-public class JpaMappingTest {
-    @Autowired FoodRepository foodRepository;
-    @Autowired HeartRepository heartRepository;
-    @Autowired MemberRepository memberRepository;
-
-    @Test
-    @DisplayName("test")
-    void test() throws Exception {
-        //given // TODO : member객체가 없어서 에러
-        Food food = new Food();
-        food.setName("Test Food");
-        foodRepository.save(food);
-        Member member = new Member();
-        memberRepository.save(member);
-
-        for (int i = 0; i < 3; i++) {
-            Heart heart = new Heart();
-            heart.setFood(food);
-            heart.setMember(member);
-            food.getHearts().add(heart);
-            System.out.println("System.identityHashCode(Heart) = " + System.identityHashCode(heart));
-            heartRepository.save(heart);
-        }
-        final Food updatedfood = foodRepository.findById(food.getId()).orElseThrow();
-        // when
-        List<Heart> hearts = updatedfood.getHearts();
-
-        // then
-        assertNotNull(food);
-        assertEquals(3, hearts.size());
-        assertTrue(hearts.stream().allMatch(heart -> heart.getFood().equals(updatedfood)));
-    }
-}
+//package core.backend.jpamapping;
+//
+//import core.backend.domain.Food;
+//import core.backend.domain.Heart;
+//import core.backend.domain.Member;
+//import core.backend.domain.RoleType;
+//import core.backend.repository.FoodRepository;
+//import core.backend.repository.HeartRepository;
+//import core.backend.repository.MemberRepository;
+//import jakarta.transaction.Transactional;
+//import org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForCalendar;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.stereotype.Component;
+//import java.util.ArrayList;
+//import java.util.List;
+//import static org.junit.jupiter.api.Assertions.*;
+//
+//@SpringBootTest
+//@Transactional
+//public class JpaMappingTest {
+//    @Autowired FoodRepository foodRepository;
+//    @Autowired HeartRepository heartRepository;
+//    @Autowired MemberRepository memberRepository;
+//
+//    @Test
+//    @DisplayName("test")
+//    void test() throws Exception {
+//        //given // TODO : member객체가 없어서 에러
+//        Food food = new Food();
+//        food.setName("Test Food");
+//        foodRepository.save(food);
+//        Member member = new Member();
+//        member.setEmail("test@test.com");
+//        member.setPassword("test");
+//        member.setRole(RoleType.ROLE_USER);
+//        member.setNationality("Test Nationality");
+//        memberRepository.save(member);
+//
+//        for (int i = 0; i < 3; i++) {
+//            Heart heart = new Heart();
+//            heart.setFood(food);
+//            heart.setMember(member);
+//            food.getHearts().add(heart);
+//            System.out.println("System.identityHashCode(Heart) = " + System.identityHashCode(heart));
+//            saveHeart(heart);
+//        }
+//        final Food updatedfood = foodRepository.findById(food.getId()).orElseThrow();
+//        // when
+//        List<Heart> hearts = updatedfood.getHearts();
+//
+//        // then
+//        assertNotNull(food);
+//        assertEquals(1, hearts.size());
+//        assertTrue(hearts.stream().allMatch(heart -> heart.getFood().equals(updatedfood)));
+//    }
+//    public void saveHeart(Heart heart) {
+//        if (heartRepository.existsByFoodAndMember(heart.getFood(), heart.getMember())) {
+//            throw new IllegalArgumentException("This food and member combination already exists.");
+//        }
+//        heartRepository.save(heart);
+//    }
+//}

--- a/backend/src/test/java/core/backend/jpamapping/JpaTest.java
+++ b/backend/src/test/java/core/backend/jpamapping/JpaTest.java
@@ -1,0 +1,44 @@
+package core.backend.jpamapping;
+
+import core.backend.domain.Food;
+import core.backend.domain.Heart;
+import core.backend.domain.Member;
+import core.backend.domain.RoleType;
+import core.backend.repository.FoodRepository;
+import core.backend.repository.HeartRepository;
+import core.backend.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent.PastOrPresentValidatorForCalendar;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.stereotype.Component;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class JpaTest {
+    @Autowired FoodRepository foodRepository;
+    @Autowired HeartRepository heartRepository;
+    @Autowired MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("연관관계 테스트")
+    void test() throws Exception {
+        //given
+        // food가 아닌 heart가 주인
+
+
+        // when
+
+
+        // then
+//        assertNotNull(food);
+//        assertEquals(3, hearts.size());
+//        assertTrue(hearts.stream().allMatch(heart -> heart.getFood().equals(updatedfood)));
+    }
+
+}


### PR DESCRIPTION
연관관계(음식 <-> 좋아요)에서 문제 발생
```java
음식에 좋아요를 추가하려 할 때

<수정 전>
food1에 heart1 추가
food1.getHearts().add(heart1) 에서 영속성 컨텍스트(?) 문제(DB에 적용이 안 됨) <- [양방향(food1 <-> heart1)]

<수정 후>
heart1에 food1 추가
heart1.set(food1) <- [단방향(food1 <- heart1)]
```